### PR TITLE
Allow overriding finishButton and cancelButton of Bootstrap screen

### DIFF
--- a/library/src/main/scala/net/liftmodules/extras/BootstrapScreen.scala
+++ b/library/src/main/scala/net/liftmodules/extras/BootstrapScreen.scala
@@ -15,8 +15,8 @@ import util.Helpers._
   * A screen with some bootstrap settings.
   */
 trait BootstrapScreen extends LiftScreen {
-  override val cancelButton = super.cancelButton % ("class" -> "btn") % ("tabindex" -> "1")
-  override val finishButton = super.finishButton % ("class" -> "btn btn-primary") % ("tabindex" -> "1")
+  override def cancelButton = super.cancelButton % ("class" -> "btn") % ("tabindex" -> "1")
+  override def finishButton = super.finishButton % ("class" -> "btn btn-primary") % ("tabindex" -> "1")
 
   override protected def renderHtml(): NodeSeq = {
     S.appendJs(afterScreenLoad)


### PR DESCRIPTION
Hey, I've updated your code in BootstrapScreen to change finishButton and cancelButton back to a 'def' rather than a 'val' so I can override them in objects that extend it.
