### PR TITLE
Version updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ target/
 # sublime-text
 *.sublime-*
 
+# Intellij IDEA
+.idea/
+
 console.devmode.log

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ liftVersion := "3.0.1"
 liftEdition := liftVersion.value.split('.').take(2).mkString(".")
 moduleName := name.value + "_" + liftEdition.value
 
-scalaVersion := "2.12.1"
-crossScalaVersions := Seq("2.12.1", "2.11.8")
+scalaVersion := crossScalaVersions.value.head
+crossScalaVersions := Seq("2.12.2", "2.11.11")
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 libraryDependencies ++=

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import LiftModule.{liftVersion, liftEdition}
+val liftVersion = settingKey[String]("Lift Web Framework full version number")
+val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
 
 name := "extras"
 organization := "net.liftmodules"

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,7 +1,0 @@
-import sbt._
-import sbt.Keys._
-
-object LiftModule {
-  val liftVersion = settingKey[String]("Lift Web Framework full version number")
-  val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
-}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
Updating scala and sbt versions. Also moved last bit of `./project/*.scala` code out to the `build.sbt` file per deprecation warnings. 

FYI, I did this while popping the hood on this project to compile it for Lift 3.1. 